### PR TITLE
Run smoke test in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,10 +1,13 @@
-all: build test clippy fmt-check forbid
+all: build test smoke clippy fmt-check forbid
 
 build:
   cargo build --all
 
 test:
   cargo test --all
+
+smoke:
+  cargo test --test smoke
 
 clippy:
   cargo clippy --all


### PR DESCRIPTION
I made it a separate target, so it's still possible to run the tests
with `just test`, even if something else is on port 8080.