### PR TITLE
Remove newline after `use super::*`

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -40,7 +40,6 @@ impl Server {
 #[cfg(test)]
 mod tests {
   use super::*;
-
   use std::net::IpAddr;
 
   #[test]


### PR DESCRIPTION
Rustfmt actually keeps `use super::*` before other imports, so I really can't object to removing the newline.