### PR TITLE
Run clippy on all targets and features

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,7 +76,6 @@ jobs:
     - name: Clippy
       run: cargo clippy --all-targets --all-features
 
-
     - name: Check Formatting
       run: cargo fmt --all -- --check
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,8 @@ jobs:
         cargo test --test smoke
 
     - name: Clippy
-      run: cargo clippy --all
+      run: cargo clippy --all-targets --all-features
+
 
     - name: Check Formatting
       run: cargo fmt --all -- --check

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ smoke:
   cargo test --test smoke
 
 clippy:
-  cargo clippy --all
+  cargo clippy --all-targets --all-features
 
 fmt-check:
   cargo fmt --all -- --check

--- a/src/request_handler.rs
+++ b/src/request_handler.rs
@@ -260,7 +260,7 @@ pub(crate) mod tests {
       let response = str::from_utf8(&response[..bytes]).unwrap();
       assert_contains(&response, "HTTP/1.1 400 Bad Request");
     });
-    assert_contains(&stderr, &format!("Invalid URL file path: /foo/../bar.txt"));
+    assert_contains(&stderr, &"Invalid URL file path: /foo/../bar.txt");
   }
 
   #[test]
@@ -274,7 +274,7 @@ pub(crate) mod tests {
         StatusCode::BAD_REQUEST
       )
     });
-    assert_contains(&stderr, &format!("Invalid URL file path: /foo//bar.txt"));
+    assert_contains(&stderr, &"Invalid URL file path: /foo//bar.txt");
   }
 
   #[test]
@@ -288,7 +288,7 @@ pub(crate) mod tests {
         StatusCode::BAD_REQUEST
       )
     });
-    assert_contains(&stderr, &format!("Invalid URL file path: //foo.txt"));
+    assert_contains(&stderr, &"Invalid URL file path: //foo.txt");
   }
 
   #[test]


### PR DESCRIPTION
I think we weren't running clippy on code behind `#[cfg(test)]`, this makes
it run on all targets, test and non-test code, and any features that we eventually
add.