### PR TITLE
Handle `--help` and `--version` correctly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,12 @@ mod stderr;
 #[tokio::main]
 async fn main() {
   if let Err(error) = run().await {
-    eprintln!("{}", error);
-    std::process::exit(1);
+    if let crate::error::Error::Clap { source } = error {
+      source.exit();
+    } else {
+      eprintln!("{}", error);
+      std::process::exit(1);
+    }
   }
 }
 

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -1,0 +1,22 @@
+use executable_path::executable_path;
+use std::process::Command;
+
+#[test]
+fn help_returns_success() {
+  assert!(Command::new(executable_path("foo"))
+    .arg("--help")
+    .output()
+    .unwrap()
+    .status
+    .success());
+}
+
+#[test]
+fn version_returns_success() {
+  assert!(Command::new(executable_path("foo"))
+    .arg("--version")
+    .output()
+    .unwrap()
+    .status
+    .success());
+}


### PR DESCRIPTION
Clap error has an `exit` method, which prints the error to stderr or stdout and exits the process with an appropriate exit code. If the error is `HelpDisplayed` or `VersionDisplayed`, output goes go to stdout, since the output is the requested output of the program, and a success error code is returned. Otherwise output goes to stderr and the process is exited with a nonzero status code.

I added tests in `tests/status.rs` that test that `--help` and `--version` that check for the correct error code. In order to get the tests not to print to stdout, I had to use `.output()`, even though I don't read the output.